### PR TITLE
Support for checking node latency:

### DIFF
--- a/check_nodes.go
+++ b/check_nodes.go
@@ -1,0 +1,123 @@
+package hasql
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+)
+
+type checkedNode struct {
+	Node    Node
+	Latency time.Duration
+}
+
+type checkedNodesList []checkedNode
+
+var _ sort.Interface = checkedNodesList{}
+
+func (list checkedNodesList) Len() int {
+	return len(list)
+}
+
+func (list checkedNodesList) Less(i, j int) bool {
+	return list[i].Latency < list[j].Latency
+}
+
+func (list checkedNodesList) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list checkedNodesList) Nodes() []Node {
+	res := make([]Node, 0, len(list))
+	for _, node := range list {
+		res = append(res, node.Node)
+	}
+
+	return res
+}
+
+type groupedCheckedNodes struct {
+	Primaries checkedNodesList
+	Standbys  checkedNodesList
+}
+
+func (nodes groupedCheckedNodes) Alive() []Node {
+	res := make([]Node, len(nodes.Primaries)+len(nodes.Standbys))
+
+	var i int
+	for len(nodes.Primaries) > 0 && len(nodes.Standbys) > 0 {
+		if nodes.Primaries[0].Latency < nodes.Standbys[0].Latency {
+			res[i] = nodes.Primaries[0].Node
+			nodes.Primaries = nodes.Primaries[1:]
+		} else {
+			res[i] = nodes.Standbys[0].Node
+			nodes.Standbys = nodes.Standbys[1:]
+		}
+
+		i++
+	}
+
+	for j := 0; j < len(nodes.Primaries); j++ {
+		res[i] = nodes.Primaries[j].Node
+		i++
+	}
+
+	for j := 0; j < len(nodes.Standbys); j++ {
+		res[i] = nodes.Standbys[j].Node
+		i++
+	}
+
+	return res
+}
+
+func checkNodes(ctx context.Context, nodes []Node, checker NodeChecker, tracer Tracer) AliveNodes {
+	checkedNodes := groupedCheckedNodes{
+		Primaries: make(checkedNodesList, 0, len(nodes)),
+		Standbys:  make(checkedNodesList, 0, len(nodes)),
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(len(nodes))
+	for _, node := range nodes {
+		go func(node Node, wg *sync.WaitGroup) {
+			defer wg.Done()
+
+			ts := time.Now()
+			primary, err := checkNode(ctx, node, checker)
+			d := time.Since(ts)
+			if err != nil {
+				if tracer.NodeDead != nil {
+					tracer.NodeDead(node, err)
+				}
+
+				return
+			}
+
+			if tracer.NodeAlive != nil {
+				tracer.NodeAlive(node)
+			}
+
+			nl := checkedNode{Node: node, Latency: d}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if primary {
+				checkedNodes.Primaries = append(checkedNodes.Primaries, nl)
+			} else {
+				checkedNodes.Standbys = append(checkedNodes.Standbys, nl)
+			}
+		}(node, &wg)
+	}
+	wg.Wait()
+
+	sort.Sort(checkedNodes.Primaries)
+	sort.Sort(checkedNodes.Standbys)
+
+	return AliveNodes{
+		Alive:     checkedNodes.Alive(),
+		Primaries: checkedNodes.Primaries.Nodes(),
+		Standbys:  checkedNodes.Standbys.Nodes(),
+	}
+}

--- a/check_nodes_test.go
+++ b/check_nodes_test.go
@@ -1,0 +1,82 @@
+package hasql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckNodes(t *testing.T) {
+	const count = 10
+	var nodes []Node
+	expected := AliveNodes{Alive: make([]Node, count)}
+	for i := 0; i < count; i++ {
+		db, _, err := sqlmock.New()
+		require.NoError(t, err)
+		require.NotNil(t, db)
+
+		node := NewNode(uuid.Must(uuid.NewV4()).String(), db)
+
+		for {
+			// Randomize 'order' (latency)
+			pos := rand.Intn(count)
+			if expected.Alive[pos] == nil {
+				expected.Alive[pos] = node
+				break
+			}
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	require.Len(t, expected.Alive, count)
+
+	// Fill primaries and standbys
+	for _, node := range expected.Alive {
+		if rand.Intn(2) == 0 {
+			expected.Primaries = append(expected.Primaries, node)
+		} else {
+			expected.Standbys = append(expected.Standbys, node)
+		}
+	}
+
+	require.NotEmpty(t, expected.Primaries)
+	require.NotEmpty(t, expected.Standbys)
+	require.Equal(t, count, len(expected.Primaries)+len(expected.Standbys))
+
+	checker := func(_ context.Context, db *sql.DB) (bool, error) {
+		for i, node := range expected.Alive {
+			if node.DB() == db {
+				// TODO: make test time-independent
+				time.Sleep(100 * time.Duration(i) * time.Millisecond)
+			}
+		}
+
+		for _, node := range expected.Primaries {
+			if node.DB() == db {
+				return true, nil
+			}
+		}
+
+		for _, node := range expected.Standbys {
+			if node.DB() == db {
+				return false, nil
+			}
+		}
+
+		return false, errors.New("node not found")
+	}
+
+	alive := checkNodes(context.Background(), nodes, checker, Tracer{})
+	assert.Equal(t, expected.Primaries, alive.Primaries)
+	assert.Equal(t, expected.Standbys, alive.Standbys)
+	assert.Equal(t, expected.Alive, alive.Alive)
+}

--- a/node_pickers.go
+++ b/node_pickers.go
@@ -36,3 +36,10 @@ func PickNodeRoundRobin() NodePicker {
 		return nodes[(int(n)-1)%len(nodes)]
 	}
 }
+
+// PickNodeClosest returns node with least latency
+func PickNodeClosest() NodePicker {
+	return func(nodes []Node) Node {
+		return nodes[0]
+	}
+}

--- a/node_pickers_test.go
+++ b/node_pickers_test.go
@@ -65,3 +65,14 @@ func TestPickNodeRoundRobin(t *testing.T) {
 	}
 	assert.Equal(t, expectedNodes, pickedNodes)
 }
+
+func TestClosest(t *testing.T) {
+	nodes := []Node{
+		NewNode("shimba", nil),
+		NewNode("boomba", nil),
+		NewNode("looken", nil),
+	}
+
+	rr := PickNodeClosest()
+	assert.Equal(t, nodes[0], rr(nodes))
+}


### PR DESCRIPTION
* all alive nodes are stored in order of their latency (from lowest to greatest)
* added PickNodeClosest - always returns 'closest' node (with least latency)