### PR TITLE
[feature] Support replication lag checking

### DIFF
--- a/checkers/check.go
+++ b/checkers/check.go
@@ -34,6 +34,8 @@ func Check(ctx context.Context, db *sql.DB, query string) (bool, error) {
 	return primary, nil
 }
 
+// ReplicationLag executes specified query on specified database pool. Query must return single time.Duration
+// value that represents its replication lag. All errors are returned as is.
 func ReplicationLag(ctx context.Context, db *sql.DB, query string) (time.Duration, error) {
 	row := db.QueryRowContext(ctx, query)
 	var lag time.Duration

--- a/checkers/check.go
+++ b/checkers/check.go
@@ -19,6 +19,7 @@ package checkers
 import (
 	"context"
 	"database/sql"
+	"time"
 )
 
 // Check executes specified query on specified database pool. Query must return single boolean
@@ -31,4 +32,14 @@ func Check(ctx context.Context, db *sql.DB, query string) (bool, error) {
 	}
 
 	return primary, nil
+}
+
+func ReplicationLag(ctx context.Context, db *sql.DB, query string) (time.Duration, error) {
+	row := db.QueryRowContext(ctx, query)
+	var lag time.Duration
+	if err := row.Scan(&lag); err != nil {
+		return 0, err
+	}
+
+	return lag, nil
 }

--- a/checkers/postgresql.go
+++ b/checkers/postgresql.go
@@ -19,9 +19,15 @@ package checkers
 import (
 	"context"
 	"database/sql"
+	"time"
 )
 
 // PostgreSQL checks whether PostgreSQL server is primary or not.
 func PostgreSQL(ctx context.Context, db *sql.DB) (bool, error) {
 	return Check(ctx, db, "SELECT NOT pg_is_in_recovery()")
+}
+
+// PostgreSQLReplicationLag returns replication lag value for PostgreSQL replica node.
+func PostgreSQLReplicationLag(ctx context.Context, db *sql.DB) (time.Duration, error) {
+	return ReplicationLag(ctx, db, "SELECT NOW() - pg_last_xact_replay_timestamp()")
 }

--- a/cluster_opts.go
+++ b/cluster_opts.go
@@ -42,6 +42,20 @@ func WithNodePicker(picker NodePicker) ClusterOption {
 	}
 }
 
+// WithReplicationLagChecker sets function to check node replication lag.
+func WithReplicationLagChecker(checker ReplicationLagChecker) ClusterOption {
+	return func(cl *Cluster) {
+		cl.lagChecker = checker
+	}
+}
+
+// WithMaxReplicationLag sets maximum replication lag for replica nodes.
+func WithMaxReplicationLag(d time.Duration) ClusterOption {
+	return func(cl *Cluster) {
+		cl.maxLagValue = d
+	}
+}
+
 // WithTracer sets tracer for actions happening in the background
 func WithTracer(tracer Tracer) ClusterOption {
 	return func(cl *Cluster) {

--- a/node.go
+++ b/node.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 )
 
 // Node of single cluster
@@ -82,3 +83,7 @@ type NodeChecker func(ctx context.Context, db *sql.DB) (bool, error)
 // NodePicker is a signature for functions that determine how to pick single node from set of nodes.
 // Nodes passed to the picker function are sorted according to latency (from lowest to greatest).
 type NodePicker func(nodes []Node) Node
+
+// ReplicationLagChecker is a signature for functions that returns current value of replication lag between
+// primary and replica nodes. If error is returned, replication considered broken.
+type ReplicationLagChecker func(ctx context.Context, db *sql.DB) (time.Duration, error)


### PR DESCRIPTION
This commit adds ability to filter replica nodes by replication lag. User can provide `ReplicationLagChecker` function and `MaxreplicationLag` value as options to cluster constructor to check nodes and remove any replica which is too slow.

Example:

```go
// Construct cluster nodes
nodes := []hasql.Node{...}

// Use options to fine-tune cluster behavior
opts := []hasql.ClusterOption{
	hasql.WithUpdateInterval(2 * time.Second),        // set custom update interval
	hasql.WithNodePicker(hasql.PickNodeRoundRobin()), // set desired nodes selection algorithm
	hasql.WithReplicationLagChecker(checkers.PostgreSQLReplicationLag), // set appropriate replication lag checker
	hasql.WithMaxReplicationLag(10 * time.Second), // set desired maximum lag value
}

// Create cluster handler
c, err := hasql.NewCluster(nodes, checkers.PostgreSQL, opts...)
if err != nil {
	panic(err)
}
defer func() { _ = c.Close() }() // close cluster when it is not needed

ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
defer cancel()

// Wait for any alive standby
node, err = c.WaitForStandby(ctx)
if err != nil {
	panic(err)
}

...
```