### PR TITLE
feature: return multierr on Close call

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}

--- a/cluster.go
+++ b/cluster.go
@@ -108,15 +108,14 @@ func NewCluster(nodes []Node, checker NodeChecker, opts ...ClusterOption) (*Clus
 func (cl *Cluster) Close() error {
 	close(cl.updateStopper)
 
-	var err error
+	var errs error
 	for _, node := range cl.nodes {
-		if e := node.DB().Close(); e != nil {
-			// TODO: This is bad, we save only one error. Need multiple-error error package.
-			err = e
+		if err := node.DB().Close(); err != nil {
+			errs = errors.Join(errs, err)
 		}
 	}
 
-	return err
+	return errs
 }
 
 // Nodes returns list of all nodes

--- a/cluster_opts_test.go
+++ b/cluster_opts_test.go
@@ -28,7 +28,6 @@ func TestClusterDefaults(t *testing.T) {
 	f := newFixture(t, 1)
 	c, err := NewCluster(f.ClusterNodes(), f.PrimaryChecker)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, c.Close()) }()
 
 	require.Equal(t, DefaultUpdateInterval, c.updateInterval)
 	require.Equal(t, DefaultUpdateTimeout, c.updateTimeout)
@@ -39,7 +38,6 @@ func TestWithUpdateInterval(t *testing.T) {
 	d := time.Hour
 	c, err := NewCluster(f.ClusterNodes(), f.PrimaryChecker, WithUpdateInterval(d))
 	require.NoError(t, err)
-	defer func() { require.NoError(t, c.Close()) }()
 
 	require.Equal(t, d, c.updateInterval)
 }
@@ -49,7 +47,6 @@ func TestWithUpdateTimeout(t *testing.T) {
 	d := time.Hour
 	c, err := NewCluster(f.ClusterNodes(), f.PrimaryChecker, WithUpdateTimeout(d))
 	require.NoError(t, err)
-	defer func() { require.NoError(t, c.Close()) }()
 
 	require.Equal(t, d, c.updateTimeout)
 }
@@ -63,7 +60,6 @@ func TestWithNodePicker(t *testing.T) {
 	f := newFixture(t, 1)
 	c, err := NewCluster(f.ClusterNodes(), f.PrimaryChecker, WithNodePicker(picker))
 	require.NoError(t, err)
-	defer func() { require.NoError(t, c.Close()) }()
 
 	c.picker(nil)
 	require.True(t, called)
@@ -79,7 +75,6 @@ func TestWithTracer(t *testing.T) {
 	f := newFixture(t, 1)
 	c, err := NewCluster(f.ClusterNodes(), f.PrimaryChecker, WithTracer(tracer))
 	require.NoError(t, err)
-	defer func() { require.NoError(t, c.Close()) }()
 
 	c.tracer.NotifiedWaiters()
 	require.Equal(t, int32(1), atomic.LoadInt32(&called))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.yandex/hasql
 
-go 1.18
+go 1.20
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRU
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=


### PR DESCRIPTION
Bumped minimal Go version to 1.20 to leverage new language feature: `errors.Join`. It allows to return all connections errors occurred while closing cluster.