### PR TITLE
Implement errors collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ cl, err := hasql.NewCluster(
 if err != nil { ... }
 
 node := cl.Primary()
-if node == nil { ... }
+if node == nil {
+    err := cl.Err() // most recent errors for all nodes in the cluster
+}
 
 // Do anything you like
 fmt.Println("Node address", node.Addr)

--- a/check_nodes.go
+++ b/check_nodes.go
@@ -93,7 +93,7 @@ type checkExecutorFunc func(ctx context.Context, node Node) (bool, time.Duration
 
 // checkNodes takes slice of nodes, checks them in parallel and returns the alive ones.
 // Accepts customizable executor which enables time-independent tests for node sorting based on 'latency'.
-func checkNodes(ctx context.Context, nodes []Node, executor checkExecutorFunc, tracer Tracer) AliveNodes {
+func checkNodes(ctx context.Context, nodes []Node, executor checkExecutorFunc, tracer Tracer, errCollector *errorsCollector) AliveNodes {
 	checkedNodes := groupedCheckedNodes{
 		Primaries: make(checkedNodesList, 0, len(nodes)),
 		Standbys:  make(checkedNodesList, 0, len(nodes)),
@@ -111,7 +111,9 @@ func checkNodes(ctx context.Context, nodes []Node, executor checkExecutorFunc, t
 				if tracer.NodeDead != nil {
 					tracer.NodeDead(node, err)
 				}
-
+				if errCollector != nil {
+					errCollector.Add(node.Addr(), err, time.Now())
+				}
 				return
 			}
 

--- a/check_nodes.go
+++ b/check_nodes.go
@@ -116,6 +116,9 @@ func checkNodes(ctx context.Context, nodes []Node, executor checkExecutorFunc, t
 				}
 				return
 			}
+			if errCollector != nil {
+				errCollector.Remove(node.Addr())
+			}
 
 			if tracer.NodeAlive != nil {
 				tracer.NodeAlive(node)

--- a/check_nodes_test.go
+++ b/check_nodes_test.go
@@ -173,7 +173,7 @@ func TestCheckNodesWithErrors(t *testing.T) {
 
 	err := errCollector.Err()
 	for i := 0; i < count; i++ {
-		assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", nodes[i].Addr()))
+		assert.ErrorContains(t, err, fmt.Sprintf("%q node error occurred at", nodes[i].Addr()))
 	}
 	assert.ErrorContains(t, err, "node not found")
 }

--- a/cluster.go
+++ b/cluster.go
@@ -58,6 +58,7 @@ type Cluster struct {
 	updateStopper chan struct{}
 	aliveNodes    atomic.Value
 	nodes         []Node
+	errCollector  *errorsCollector
 
 	// Notification
 	muWaiters sync.Mutex
@@ -89,6 +90,7 @@ func NewCluster(nodes []Node, checker NodeChecker, opts ...ClusterOption) (*Clus
 		checker:        checker,
 		picker:         PickNodeRandom(),
 		nodes:          nodes,
+		errCollector:   newErrorsCollector(),
 	}
 
 	// Apply options
@@ -291,6 +293,10 @@ func (cl *Cluster) node(nodes AliveNodes, criteria NodeStateCriteria) Node {
 	}
 }
 
+func (cl *Cluster) Err() error {
+	return cl.errCollector.Err()
+}
+
 // backgroundNodesUpdate periodically updates list of live db nodes
 func (cl *Cluster) backgroundNodesUpdate() {
 	// Initial update
@@ -318,7 +324,7 @@ func (cl *Cluster) updateNodes() {
 	ctx, cancel := context.WithTimeout(context.Background(), cl.updateTimeout)
 	defer cancel()
 
-	alive := checkNodes(ctx, cl.nodes, checkExecutor(cl.checker), cl.tracer)
+	alive := checkNodes(ctx, cl.nodes, checkExecutor(cl.checker), cl.tracer, cl.errCollector)
 	cl.aliveNodes.Store(alive)
 
 	if cl.tracer.UpdatedNodes != nil {

--- a/cluster.go
+++ b/cluster.go
@@ -58,7 +58,7 @@ type Cluster struct {
 	updateStopper chan struct{}
 	aliveNodes    atomic.Value
 	nodes         []Node
-	errCollector  *errorsCollector
+	errCollector  errorsCollector
 
 	// Notification
 	muWaiters sync.Mutex
@@ -293,6 +293,8 @@ func (cl *Cluster) node(nodes AliveNodes, criteria NodeStateCriteria) Node {
 	}
 }
 
+// Err returns the combined error including most recent errors for all nodes.
+// This error is CollectedErrors or nil.
 func (cl *Cluster) Err() error {
 	return cl.errCollector.Err()
 }
@@ -324,7 +326,7 @@ func (cl *Cluster) updateNodes() {
 	ctx, cancel := context.WithTimeout(context.Background(), cl.updateTimeout)
 	defer cancel()
 
-	alive := checkNodes(ctx, cl.nodes, checkExecutor(cl.checker), cl.tracer, cl.errCollector)
+	alive := checkNodes(ctx, cl.nodes, checkExecutor(cl.checker), cl.tracer, &cl.errCollector)
 	cl.aliveNodes.Store(alive)
 
 	if cl.tracer.UpdatedNodes != nil {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -568,8 +568,8 @@ func TestCluster_Err(t *testing.T) {
 
 				err := cl.Err()
 				require.Error(t, err)
-				assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", f.Nodes[0].Node.Addr()))
-				assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", f.Nodes[1].Node.Addr()))
+				assert.ErrorContains(t, err, fmt.Sprintf("%q node error occurred at", f.Nodes[0].Node.Addr()))
+				assert.ErrorContains(t, err, fmt.Sprintf("%q node error occurred at", f.Nodes[1].Node.Addr()))
 			},
 		},
 		{
@@ -581,8 +581,8 @@ func TestCluster_Err(t *testing.T) {
 
 				err := cl.Err()
 				require.Error(t, err)
-				assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", f.Nodes[0].Node.Addr()))
-				assert.NotContains(t, err.Error(), fmt.Sprintf("'%s' node error occurred at", f.Nodes[1].Node.Addr()))
+				assert.ErrorContains(t, err, fmt.Sprintf("%q node error occurred at", f.Nodes[0].Node.Addr()))
+				assert.NotContains(t, err.Error(), fmt.Sprintf("%q node error occurred at", f.Nodes[1].Node.Addr()))
 			},
 		},
 		{
@@ -594,8 +594,8 @@ func TestCluster_Err(t *testing.T) {
 
 				err := cl.Err()
 				require.Error(t, err)
-				assert.NotContains(t, err.Error(), fmt.Sprintf("'%s' node error occurred at", f.Nodes[0].Node.Addr()))
-				assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", f.Nodes[1].Node.Addr()))
+				assert.NotContains(t, err.Error(), fmt.Sprintf("%q node error occurred at", f.Nodes[0].Node.Addr()))
+				assert.ErrorContains(t, err, fmt.Sprintf("%q node error occurred at", f.Nodes[1].Node.Addr()))
 			},
 		},
 	}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -568,8 +568,8 @@ func TestCluster_Err(t *testing.T) {
 
 				err := cl.Err()
 				require.Error(t, err)
-				assert.ErrorContains(t, err, fmt.Sprintf("error on node %s", f.Nodes[0].Node.Addr()))
-				assert.ErrorContains(t, err, fmt.Sprintf("error on node %s", f.Nodes[1].Node.Addr()))
+				assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", f.Nodes[0].Node.Addr()))
+				assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", f.Nodes[1].Node.Addr()))
 			},
 		},
 		{
@@ -581,8 +581,8 @@ func TestCluster_Err(t *testing.T) {
 
 				err := cl.Err()
 				require.Error(t, err)
-				assert.ErrorContains(t, err, fmt.Sprintf("error on node %s", f.Nodes[0].Node.Addr()))
-				assert.NotContains(t, err.Error(), fmt.Sprintf("error on node %s", f.Nodes[1].Node.Addr()))
+				assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", f.Nodes[0].Node.Addr()))
+				assert.NotContains(t, err.Error(), fmt.Sprintf("'%s' node error occurred at", f.Nodes[1].Node.Addr()))
 			},
 		},
 		{
@@ -594,8 +594,8 @@ func TestCluster_Err(t *testing.T) {
 
 				err := cl.Err()
 				require.Error(t, err)
-				assert.NotContains(t, err.Error(), fmt.Sprintf("error on node %s", f.Nodes[0].Node.Addr()))
-				assert.ErrorContains(t, err, fmt.Sprintf("error on node %s", f.Nodes[1].Node.Addr()))
+				assert.NotContains(t, err.Error(), fmt.Sprintf("'%s' node error occurred at", f.Nodes[0].Node.Addr()))
+				assert.ErrorContains(t, err, fmt.Sprintf("'%s' node error occurred at", f.Nodes[1].Node.Addr()))
 			},
 		},
 	}

--- a/errors_collector.go
+++ b/errors_collector.go
@@ -1,0 +1,70 @@
+/*
+   Copyright 2020 YANDEX LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package hasql
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+type nodeError struct {
+	addr       string
+	err        error
+	occurredAt time.Time
+}
+
+type errorsCollector struct {
+	store map[string]nodeError
+	mu    sync.Mutex
+}
+
+func newErrorsCollector() *errorsCollector {
+	return &errorsCollector{store: make(map[string]nodeError)}
+}
+
+func (e *errorsCollector) Add(addr string, err error, occurredAt time.Time) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.store[addr] = nodeError{
+		addr:       addr,
+		err:        err,
+		occurredAt: occurredAt,
+	}
+}
+
+func (e *errorsCollector) Err() (errs error) {
+	errList := make([]nodeError, 0, len(e.store))
+	for _, nErr := range e.store {
+		errList = append(errList, nErr)
+	}
+	sort.Slice(errList, func(i, j int) bool {
+		return errList[i].occurredAt.Before(errList[j].occurredAt)
+	})
+	for _, nErr := range errList {
+		err := fmt.Errorf("error on node %s occurred at %v: %w", nErr.addr, nErr.occurredAt, nErr.err)
+		// use errs = errors.Join(errs, err) when support go<1.20 will be dropped + change to desc errList soring above
+		if errs == nil {
+			errs = err
+		} else {
+			errs = fmt.Errorf("%w; %w", err, errs)
+		}
+	}
+	return
+}

--- a/errors_collector.go
+++ b/errors_collector.go
@@ -56,7 +56,7 @@ type NodeError struct {
 
 func (e *NodeError) Error() string {
 	// 'foo.db' node error occurred at '2009-11-10..': FATAL: terminating connection due to ...
-	return fmt.Sprintf("'%s' node error occurred at '%s': %s", e.Addr, e.OccurredAt, e.Err)
+	return fmt.Sprintf("%q node error occurred at %q: %s", e.Addr, e.OccurredAt, e.Err)
 }
 
 type errorsCollector struct {

--- a/errors_collector_test.go
+++ b/errors_collector_test.go
@@ -67,7 +67,7 @@ func TestErrorsCollector(t *testing.T) {
 
 	err := errCollector.Err()
 	for i := 1; i <= nodesCount; i++ {
-		assert.ErrorContains(t, err, fmt.Sprintf("'node-%d' node error occurred at", i))
+		assert.ErrorContains(t, err, fmt.Sprintf("\"node-%d\" node error occurred at", i))
 	}
 	assert.ErrorContains(t, err, connErr.Error())
 

--- a/errors_collector_test.go
+++ b/errors_collector_test.go
@@ -1,0 +1,57 @@
+/*
+   Copyright 2020 YANDEX LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package hasql
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorsCollector(t *testing.T) {
+	nodesCount := 10
+	errCollector := newErrorsCollector()
+	require.NoError(t, errCollector.Err())
+
+	connErr := errors.New("node connection error")
+	occurredAt := time.Now()
+
+	var wg sync.WaitGroup
+	wg.Add(nodesCount)
+	for i := 1; i <= nodesCount; i++ {
+		go func(i int) {
+			defer wg.Done()
+			errCollector.Add(
+				fmt.Sprintf("node-%d", i),
+				connErr,
+				occurredAt,
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	err := errCollector.Err()
+	for i := 1; i <= nodesCount; i++ {
+		assert.ErrorContains(t, err, fmt.Sprintf("error on node node-%d", i))
+	}
+	assert.ErrorContains(t, err, connErr.Error())
+}


### PR DESCRIPTION
### Motivation
Currently it's hard to understand what are the issues if the database cluster doesn't return any nodes.
```go
node := cl.Primary()
if node == nil {
    // why it happens?
}
```
The only way is to check the logs written by the custom `Tracer` implementation, but it's not very convenient.

### Solution
1. Implement errors collector that collects most recent errors for each node in the cluster.
2. Add `Cluster#Err()`  method that returns the combined error including most recent errors for all nodes in descending order by the time of occurrence.
```go
node := cl.Primary()
if node == nil {
    return fmt.Errorf("all primary node are unavailable, reasons: %w", cl.Err())
}
```