### PR TITLE
Fix typos in comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,7 +47,7 @@ output:
 # all available settings of specific linters
 linters-settings:
   errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.
     check-type-assertions: false
 

--- a/checked_node_test.go
+++ b/checked_node_test.go
@@ -382,7 +382,7 @@ func TestPickNodeByCriterion(t *testing.T) {
 		picker := new(RandomNodePicker[*sql.DB])
 
 		assert.Equal(t, node, pickNodeByCriterion(nodes, picker, Primary))
-		// we will return node on Prefer* creterias also
+		// we will return node on Prefer* criteria also
 		assert.Equal(t, node, pickNodeByCriterion(nodes, picker, PreferPrimary))
 		assert.Equal(t, node, pickNodeByCriterion(nodes, picker, PreferStandby))
 	})
@@ -406,7 +406,7 @@ func TestPickNodeByCriterion(t *testing.T) {
 		picker := new(RandomNodePicker[*sql.DB])
 
 		assert.Equal(t, node, pickNodeByCriterion(nodes, picker, Standby))
-		// we will return node on Prefer* creterias also
+		// we will return node on Prefer* criteria also
 		assert.Equal(t, node, pickNodeByCriterion(nodes, picker, PreferPrimary))
 		assert.Equal(t, node, pickNodeByCriterion(nodes, picker, PreferStandby))
 	})

--- a/cluster_opts.go
+++ b/cluster_opts.go
@@ -35,7 +35,7 @@ func WithUpdateTimeout[T Querier](d time.Duration) ClusterOpt[T] {
 	}
 }
 
-// WithNodePicker sets algorithm for node selection (e.g. random, round robin etc)
+// WithNodePicker sets algorithm for node selection (e.g. random, round robin etc.)
 func WithNodePicker[T Querier](picker NodePicker[T]) ClusterOpt[T] {
 	return func(cl *Cluster[T]) {
 		cl.picker = picker

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -178,7 +178,7 @@ func TestCluster_Node(t *testing.T) {
 		})
 
 		assert.Equal(t, node, cl.Node(Primary))
-		// we will return node on Prefer* creterias also
+		// we will return node on Prefer* criteria also
 		assert.Equal(t, node, cl.Node(PreferPrimary))
 		assert.Equal(t, node, cl.Node(PreferStandby))
 	})
@@ -203,7 +203,7 @@ func TestCluster_Node(t *testing.T) {
 		})
 
 		assert.Equal(t, node, cl.Node(Standby))
-		// we will return node on Prefer* creterias also
+		// we will return node on Prefer* criteria also
 		assert.Equal(t, node, cl.Node(PreferPrimary))
 		assert.Equal(t, node, cl.Node(PreferStandby))
 	})

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,7 @@ import (
 	"golang.yandex/hasql/v2"
 )
 
-// ExampleCluster shows how to setup basic hasql cluster with some suctom settings
+// ExampleCluster shows how to setup basic hasql cluster with some custom settings
 func ExampleCluster() {
 	// open connections to database instances
 	db1, err := sql.Open("pgx", "host1.example.com")

--- a/node_checker.go
+++ b/node_checker.go
@@ -26,7 +26,7 @@ import (
 type NodeRole uint8
 
 const (
-	// NodeRoleUnknown used to report node with unconvetional role in cluster
+	// NodeRoleUnknown used to report node with unconventional role in cluster
 	NodeRoleUnknown NodeRole = iota
 	// NodeRolePrimary used to report node with primary role in cluster
 	NodeRolePrimary

--- a/node_discoverer.go
+++ b/node_discoverer.go
@@ -31,7 +31,7 @@ type NodeDiscoverer[T Querier] interface {
 // StaticNodeDiscoverer implements NodeDiscoverer
 var _ NodeDiscoverer[*sql.DB] = (*StaticNodeDiscoverer[*sql.DB])(nil)
 
-// StaticNodeDiscoverer returns always returns list of provided nodes
+// StaticNodeDiscoverer always returns list of provided nodes
 type StaticNodeDiscoverer[T Querier] struct {
 	nodes []*Node[T]
 }

--- a/notify.go
+++ b/notify.go
@@ -22,7 +22,7 @@ type updateSubscriber[T Querier] struct {
 	criterion NodeStateCriterion
 }
 
-// addUpdateSubscriber adds new dubscriber to notification pool
+// addUpdateSubscriber adds new subscriber to notification pool
 func (cl *Cluster[T]) addUpdateSubscriber(criterion NodeStateCriterion) <-chan *Node[T] {
 	// buffered channel is essential
 	// read WaitForNode function for more information
@@ -33,7 +33,7 @@ func (cl *Cluster[T]) addUpdateSubscriber(criterion NodeStateCriterion) <-chan *
 	return ch
 }
 
-// notifyUpdateSubscribers sends appropriate nodes to registered subsribers.
+// notifyUpdateSubscribers sends appropriate nodes to registered subscribers.
 // This function uses newly checked nodes to avoid race conditions
 func (cl *Cluster[T]) notifyUpdateSubscribers(nodes CheckedNodes[T]) {
 	cl.subscribersMu.Lock()


### PR DESCRIPTION
Fix typos that i found in comments of project:

- unconvetional -> unconventional
- dubscriber -> subscriber
- subsribers -> subscribers
- suctom -> custom
- creterias -> criteria
- assetions -> assertions

Also changes:
- etc -> etc.

And removes repeated word:
- "returns always returns" -> "always returns"

To find misspellings i've used [cspell](https://github.com/streetsidesoftware/cspell) tool.
