### PR TITLE
NodesIter method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}
@@ -28,7 +28,7 @@ jobs:
       run: go test -race ./... -coverprofile=coverage.txt -covermode=atomic
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
-      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.x'
+      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24.x'
       with:
         file: ./coverage.txt
         flags: unittests

--- a/checked_node_test.go
+++ b/checked_node_test.go
@@ -96,6 +96,16 @@ func TestCheckNodes(t *testing.T) {
 				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
 				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 70}},
 			},
+			primariesPrior: []CheckedNode[*mockQuerier]{
+				{Node: node1, Info: NodeInfo{ClusterRole: NodeRolePrimary, NetworkLatency: 100}},
+				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 70}},
+			},
+			standbysPrior: []CheckedNode[*mockQuerier]{
+				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 70}},
+				{Node: node1, Info: NodeInfo{ClusterRole: NodeRolePrimary, NetworkLatency: 100}},
+			},
 		}
 
 		assert.Equal(t, expected, checked)
@@ -198,6 +208,14 @@ func TestCheckNodes(t *testing.T) {
 			standbys: []CheckedNode[*mockQuerier]{
 				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
 			},
+			primariesPrior: []CheckedNode[*mockQuerier]{
+				{Node: node1, Info: NodeInfo{ClusterRole: NodeRolePrimary, NetworkLatency: 100}},
+				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+			},
+			standbysPrior: []CheckedNode[*mockQuerier]{
+				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+				{Node: node1, Info: NodeInfo{ClusterRole: NodeRolePrimary, NetworkLatency: 100}},
+			},
 			err: NodeCheckErrors[*mockQuerier]{
 				{node: node3, err: io.EOF},
 			},
@@ -256,6 +274,14 @@ func TestCheckNodes(t *testing.T) {
 			},
 			primaries: []CheckedNode[*mockQuerier]{},
 			standbys: []CheckedNode[*mockQuerier]{
+				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 70}},
+			},
+			primariesPrior: []CheckedNode[*mockQuerier]{
+				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 70}},
+			},
+			standbysPrior: []CheckedNode[*mockQuerier]{
 				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
 				{Node: node2, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 70}},
 			},
@@ -320,6 +346,14 @@ func TestCheckNodes(t *testing.T) {
 			},
 			standbys: []CheckedNode[*mockQuerier]{
 				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+			},
+			primariesPrior: []CheckedNode[*mockQuerier]{
+				{Node: node2, Info: NodeInfo{ClusterRole: NodeRolePrimary, NetworkLatency: 20}},
+				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+			},
+			standbysPrior: []CheckedNode[*mockQuerier]{
+				{Node: node3, Info: NodeInfo{ClusterRole: NodeRoleStandby, NetworkLatency: 50}},
+				{Node: node2, Info: NodeInfo{ClusterRole: NodeRolePrimary, NetworkLatency: 20}},
 			},
 			err: NodeCheckErrors[*mockQuerier]{
 				{node: node1, err: errors.New("cannot determine node role")},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.yandex/hasql/v2
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
This is a draft PR addressing issue #16. It introduces new cluster method `NodesIter` that allows user to iterate over nodes in sequence:

```go
type Store struct {
	// cluster contains 1 primary and 2 standbys
	cluster *hasql.Cluster[*sql.DB]
}

func (s *Store) FindUserByID(ctx context.Context, id int64) (*User, error) {
	// iterate over nodes in sequence [standby, standby, primary]
	for node := range s.cluster.NodesIter(hasql.PreferStandby) {
		var user User

		err := node.DB().
			QueryRowContext(`SELECT login, email FROM users WHERE id = $1`, id).
			Scan(&user.Login, &user.Email)
		if err == nil {
			return &user, nil
		}
	}

	return nil, errors.New("all attempts to fetch user have failed")
}
```

Current code is in preview state and I'm open for discussion.